### PR TITLE
Prevented different users from sharing sessions

### DIFF
--- a/DupcheckExternalModule.php
+++ b/DupcheckExternalModule.php
@@ -22,10 +22,9 @@ class DupcheckExternalModule extends AbstractExternalModule
             $projectIDs = $this->getProjectSetting('project-id');
             $fields = $this->getProjectSetting('field');
 
-            $sess_id_1 = session_id();
-            $sess_id_2 = "cross-duplicate-module";
+            $originalSessionName = session_name();
             session_write_close();
-            session_id($sess_id_2);
+            session_name("cross-duplicate-module");
             session_start();
 
             if (empty($_SESSION['survey_piping_token'])) {
@@ -83,7 +82,7 @@ class DupcheckExternalModule extends AbstractExternalModule
             </script>";
 
             session_write_close();
-            session_id($sess_id_1);
+            session_name($originalSessionName);
             session_start();
             echo $javaString;
         }

--- a/ajax_data.php
+++ b/ajax_data.php
@@ -1,20 +1,15 @@
 <?php
 
-session_name("cross-duplicate-module");
-session_start();
-
-define("NOAUTH",true);
-
-$fieldList = $_POST['fields'];
-$projects = $_POST['projects'];
-$fieldValues = $_POST['fieldValues'];
-$project_id = $_POST['currentproject'];
+$fieldList = $payload['fields'];
+$projects = $payload['projects'];
+$fieldValues = $payload['fieldValues'];
+$project_id = $payload['currentproject'];
 $currentProject = new \Project($project_id);
 $currentMeta = $currentProject->metadata;
 $dateValidations = array('date_mdy','date_dmy','date_ymd','datetime_mdy','datetime_dmy','datetime_ymd','datetime_seconds_mdy','datetime_seconds_dmy','datetime_seconds_ymd');
 
 $duplicate = "0";
-$alertMessage = $module->getProjectSetting('alert-message');
+$alertMessage = $this->getProjectSetting('alert-message');
 $fieldData = array();
 
 foreach ($fieldList as $index => $fieldName) {
@@ -23,36 +18,32 @@ foreach ($fieldList as $index => $fieldName) {
 
 $alertMessage = parseRecordSetting($alertMessage,$fieldData);
 
-if (!empty($_POST['token'])) {
-    if (hash_equals($_SESSION['survey_piping_token'], $_POST['token'])) {
-        $fieldNameValues = array();
-        foreach ($fieldList as $index => $field) {
-            if (validateDate($fieldValues[$index][0],$module->getDateFormat($currentMeta[$field]['element_validation_type'], $field, 'php'))) {
-                if (in_array($currentMeta[$field]['element_validation_type'], $dateValidations)) {
-                    $dateFormatting = $module->getDateFormat($currentMeta[$field]['element_validation_type'], $field, 'php');
-                    $date = DateTime::createFromFormat($dateFormatting, $fieldValues[$index][0]);
-                    $fieldValues[$index][0] = $date->format("Y-m-d");
-                }
-            }
-            $fieldNameValues[$index] = "[".$field."] = '".$fieldValues[$index][0]."'";
+$fieldNameValues = array();
+foreach ($fieldList as $index => $field) {
+    if (validateDate($fieldValues[$index][0],$this->getDateFormat($currentMeta[$field]['element_validation_type'], $field, 'php'))) {
+        if (in_array($currentMeta[$field]['element_validation_type'], $dateValidations)) {
+            $dateFormatting = $this->getDateFormat($currentMeta[$field]['element_validation_type'], $field, 'php');
+            $date = DateTime::createFromFormat($dateFormatting, $fieldValues[$index][0]);
+            $fieldValues[$index][0] = $date->format("Y-m-d");
         }
+    }
+    $fieldNameValues[$index] = "[".$field."] = '".$fieldValues[$index][0]."'";
+}
 
-        foreach ($projects as $projectID) {
-            $recordData = json_decode(\REDCap::getData($projectID,'json',array(),$fieldList,array(), array(), false, false, false, implode(" AND ",$fieldNameValues)),true);
+foreach ($projects as $projectID) {
+    $recordData = json_decode(\REDCap::getData($projectID,'json',array(),$fieldList,array(), array(), false, false, false, implode(" AND ",$fieldNameValues)),true);
 
-            if (!empty($recordData)) {
-                $currentProject = new \Project($projectID);
-                $projectName = $currentProject->project['app_title'];
-                if ($duplicate == "0") {
-                    $duplicate = $alertMessage."\n";
-                }
-                $duplicate .= $projectName."\n";
-            }
+    if (!empty($recordData)) {
+        $currentProject = new \Project($projectID);
+        $projectName = $currentProject->project['app_title'];
+        if ($duplicate == "0") {
+            $duplicate = $alertMessage."\n";
         }
+        $duplicate .= $projectName."\n";
     }
 }
 
-echo $duplicate;
+return $duplicate;
 
 function parseRecordSetting($recordsetting,$recorddata) {
     $returnString = $recordsetting;

--- a/ajax_data.php
+++ b/ajax_data.php
@@ -1,10 +1,6 @@
 <?php
 
-session_start();
-$sess_id_1 = session_id();
-$sess_id_2 = "cross-duplicate-module";
-session_write_close();
-session_id($sess_id_2);
+session_name("cross-duplicate-module");
 session_start();
 
 define("NOAUTH",true);
@@ -55,10 +51,6 @@ if (!empty($_POST['token'])) {
         }
     }
 }
-
-session_write_close();
-session_id($sess_id_1);
-session_start();
 
 echo $duplicate;
 

--- a/config.json
+++ b/config.json
@@ -7,6 +7,10 @@
 
 	"framework-version": 11,
 
+	"auth-ajax-actions": [
+		"check for duplicates"
+	],
+
 	"no-auth-ajax-actions": [
 		"check for duplicates"
 	],

--- a/config.json
+++ b/config.json
@@ -5,6 +5,12 @@
 
 	"description": "Checks for duplicate records (as defined by a certain number of matching fields) across one or more projects. If the field matches across multiple records, a duplicate is reported. (Does not currently work for repeating instruments/events.)",
 
+	"framework-version": 11,
+
+	"no-auth-ajax-actions": [
+		"check for duplicates"
+	],
+
     "authors": [
         {
             "name": "Scott J. Pearson",
@@ -25,20 +31,16 @@
 		"project": [
 			{
 				"name": "Check for Duplicates in This Project",
-				"icon": "report",
+				"icon": "fa-solid fa-copy",
 				"url": "dupcheck_here.php"
 			},
 			{
 				"name": "Check for Duplicates in All Projects",
-				"icon": "report",
+				"icon": "fa-solid fa-copy",
 				"url": "dupcheck_all.php"
 			}
 		]
 	},
-
-	"no-auth-pages":[
-		"ajax_data"
-	],
 
 	"project-settings": [
 		{
@@ -65,5 +67,8 @@
 			"name": "Alert Message on Duplication",
 			"type": "text"
 		}
-	]
+	],
+	"compatibility": {
+		"php-version-min": "12.5.9"
+	}
 }

--- a/config.json
+++ b/config.json
@@ -69,6 +69,6 @@
 		}
 	],
 	"compatibility": {
-		"php-version-min": "12.5.9"
+		"redcap-version-min": "12.5.9"
 	}
 }


### PR DESCRIPTION
@moorejr5, I believe setting `session_id` to a static string was causing all requests to these pages to share a single session.  I think using `session_name` is what was was originally intended conceptually.

The ajax feature built into the framework didn't exist back when this was written, but would avoid the need for manual session handling on future cases like this.